### PR TITLE
Support injection within lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ gulp.task('inject', function () {
                     // can use custom regex pattern here
                     // <filename> token will be replaced by filename regex pattern.
 					// do not use capturing groups within your custom regex.
-                    // this parameter is optional, default value: '<!--\s*inject:<filename>-->'
-                    pattern: '<!--\s*inject:<filename>-->'
+                    // this parameter is optional, default value: '<!--\\s*inject:<filename>-->'
+                    pattern: '<!--\\s*inject:<filename>-->'
                 }));
 });
 ```

--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ gulp.task('inject', function () {
     return gulp.src('./src/main.xml')
                 .pipe(injectfile({
                     // can use custom regex pattern here
-                    // <filename> token will be replaces by filename regex pattern.
-                    // this parameter is optional, default value: '<!-- inject\\:<filename> -->'
-                    pattern: '<!--\\sinject:<filename>-->'
+                    // <filename> token will be replaced by filename regex pattern.
+					// do not use capturing groups within your custom regex.
+                    // this parameter is optional, default value: '<!--\s*inject:<filename>-->'
+                    pattern: '<!--\s*inject:<filename>-->'
                 }));
 });
 ```

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const PLUGIN_NAME = 'gulp-inject-file';
 function gulpInjectFile(opts) {
     const FILENAME_PATTERN = '\\s*([\\w\\-.\\\\/]+)\\s*'; //Unescaped \s*([\w\-.\\\/]+)\s*
     const FILENAME_MARKER = '<filename>';
-    const DEFAULT_PATTERN = '<!--\s*inject:<filename>-->';
+    const DEFAULT_PATTERN = '<!--\\s*inject:<filename>-->';
 
     opts = opts || {};
     opts.pattern = opts.pattern || DEFAULT_PATTERN;

--- a/index.js
+++ b/index.js
@@ -8,9 +8,9 @@ var PluginError = gutil.PluginError;
 const PLUGIN_NAME = 'gulp-inject-file';
 
 function gulpInjectFile(opts) {
-    const FILENAME_PATTERN = '\\s*([\\w\\-\\_\\.\\\\\\/]+)';
+    const FILENAME_PATTERN = '\\s*([\\w\\-.\\\\/]+)\\s*'; //Unescaped \s*([\w\-.\\\/]+)\s*
     const FILENAME_MARKER = '<filename>';
-    const DEFAULT_PATTERN = '<!-- inject\\:<filename> -->';
+    const DEFAULT_PATTERN = '<!--\s*inject:<filename>-->';
 
     opts = opts || {};
     opts.pattern = opts.pattern || DEFAULT_PATTERN;
@@ -21,20 +21,21 @@ function gulpInjectFile(opts) {
 
         if (isBuffer) {
             var content = file.contents.toString('utf8');
-            var injectPattern = '^([\\t ]*)' + opts.pattern.replace(FILENAME_MARKER, FILENAME_PATTERN);
+            var injectPattern = '^([ \\t]*)(.*?)' + opts.pattern.replace(FILENAME_MARKER, FILENAME_PATTERN);
             var regex = new RegExp(injectPattern, 'm');
-            var fileName, whitespace;
+            var fileName, textBefore, whitespace;
 
             while (currMatch = regex.exec(content)) {
                 match = currMatch[0];
                 whitespace = currMatch[1];
-                fileName = currMatch[2];
+				textBefore = currMatch[2];
+                fileName = currMatch[3];
 
-                var injectContent = _(getFileContent(path.join(path.dirname(file.path), fileName)).split(/\r?\n/))
-                    .map(function(line) {
-                        return whitespace + line;
+                var injectContent = whitespace + textBefore + 
+					_(getFileContent(path.join(path.dirname(file.path), fileName)).split(/\r?\n/))
+                    .map(function(line, i) {
+                        return (i > 0) ? whitespace + line : line;
                     })
-                    .value()
                     .join('\n');
 
                 content = content.replace(match, injectContent);

--- a/test/expected/withinline/main.xml
+++ b/test/expected/withinline/main.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<data>
+	<existing><sub-item1 /><sub-item2 /></existing>
+</data>

--- a/test/fixtures/withinline/main.xml
+++ b/test/fixtures/withinline/main.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<data>
+	<existing><!-- inject: ./sections/subitem.xml --></existing>
+</data>

--- a/test/fixtures/withinline/sections/subitem.xml
+++ b/test/fixtures/withinline/sections/subitem.xml
@@ -1,0 +1,1 @@
+<sub-item1 /><sub-item2 />

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -69,6 +69,7 @@ describe('gulp-inject-file', function() {
 				expect(newFile).to.exist;
 				expect(newFile.contents).to.exist;
 				expect(newFile.contents.toString('utf8')).to.equal(fs.readFileSync('test/expected/withinline/main.xml', 'utf8'));
+				done();
 			});
 			
 			stream.write(file);
@@ -89,6 +90,7 @@ describe('gulp-inject-file', function() {
 				expect(newFile).to.exist;
 				expect(newFile.contents).to.exist;
 				expect(newFile.contents.toString('utf8')).to.equal(fs.readFileSync('test/expected/withinline/main.xml', 'utf8'));
+				done();
 			});
 			
 			stream.write(file);

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -52,6 +52,48 @@ describe('gulp-inject-file', function() {
             stream.write(file);
             stream.end();
         });
+		
+		it('should inject file within a line by pattern', function(done) {
+			var file = new gutil.File({
+				path: 'test/fixtures/withinline/main.xml',
+				cwd: 'test/fixtures/withinline/',
+				base: 'test/fixtures/withinline/',
+				contents: fs.readFileSync('test/fixtures/withinline/main.xml')
+			});
+			
+			var stream = injectFilePlugin({
+				pattern: '<!-- inject\\:<filename> -->'
+			});
+			
+			stream.on('data', function(newFile) {
+				expect(newFile).to.exist;
+				expect(newFile.contents).to.exist;
+				expect(newFile.contents.toString('utf8')).to.equal(fs.readFileSync('test/expected/withinline/main.xml', 'utf8'));
+			});
+			
+			stream.write(file);
+            stream.end();
+		});
+		
+		it('should inject file within a line using default pattern', function(done) {
+			var file = new gutil.File({
+				path: 'test/fixtures/withinline/main.xml',
+				cwd: 'test/fixtures/withinline/',
+				base: 'test/fixtures/withinline/',
+				contents: fs.readFileSync('test/fixtures/withinline/main.xml')
+			});
+			
+			var stream = injectFilePlugin();
+			
+			stream.on('data', function(newFile) {
+				expect(newFile).to.exist;
+				expect(newFile.contents).to.exist;
+				expect(newFile.contents.toString('utf8')).to.equal(fs.readFileSync('test/expected/withinline/main.xml', 'utf8'));
+			});
+			
+			stream.write(file);
+            stream.end();
+		});
 
         describe('transformation', function() {
             var file, transformMock, pattern, options;


### PR DESCRIPTION
Changes: 
- Regex tweaks to make the default regex more likely to capture attempted injections
- Replace function change to support injection within lines, instead of alone in lines. 

Example:
Given this structure:

```
└── src
    └── index.html
        └── subitems
            └── more.html
```

With the target file being `index.html` and having the content

```
...
    <div><!-- inject: ./subitems/more.html --></div>
...
```

If more.html has the content 

```
<h3>More info</h3>
<div>
    <p>Indented info</p>
</div>
```

The output would be 

```
...
    <div><!-- inject: ./subitems/more.html --></div>
...
```

This change would allow the output to be the expected

```
...
    <div><h3>More info</h3>
    <div>
        <p>Indented info</p>
    </div></div>
...
```

Thanks for creating this extension, it has helped me a great deal. 
