### PR TITLE
Ignore special symbols when doing file content replace

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function gulpInjectFile(opts) {
                     })
                     .join('\n');
 
-                content = content.replace(match, injectContent);
+                content = content.replace(match, function() { return injectContent; });
             }
 
             file.contents = new Buffer(content);


### PR DESCRIPTION
I bumped into issue that String.replace can accept special symbols like $& that replaced in a string that should be inserted as substituted value. (https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter). All it comes that, for example, it was unable to inject jQuery content somewhere. This is a fix for that.
