### PR TITLE
Support injecting files with  @ and/or _ in their name/path

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var PluginError = gutil.PluginError;
 const PLUGIN_NAME = 'gulp-inject-file';
 
 function gulpInjectFile(opts) {
-    const FILENAME_PATTERN = '\\s*([\\w\\-.\\\\/]+)\\s*'; //Unescaped \s*([\w\-.\\\/]+)\s*
+    const FILENAME_PATTERN = '\\s*([\\w@_\\-.\\\\/]+)\\s*'; //Unescaped \s*([\w@_\-.\\\/]+)\s*
     const FILENAME_MARKER = '<filename>';
     const DEFAULT_PATTERN = '<!--\\s*inject:<filename>-->';
 

--- a/test/expected/inject/at-sign-underscore.xml
+++ b/test/expected/inject/at-sign-underscore.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<data>
+	<existing />
+	<sub-item1 />
+	<sub-item2 />
+</data>

--- a/test/fixtures/inject/at-sign-underscore.xml
+++ b/test/fixtures/inject/at-sign-underscore.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<data>
+	<existing />
+	<!-- inject: ./dirwith@sign/sub_item.xml -->
+</data>

--- a/test/fixtures/inject/dirwith@sign/sub_item.xml
+++ b/test/fixtures/inject/dirwith@sign/sub_item.xml
@@ -1,0 +1,2 @@
+<sub-item1 />
+<sub-item2 />

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -97,6 +97,29 @@ describe('gulp-inject-file', function() {
             stream.end();
 		});
 
+        it('should inject file with path including at sign or underscore by pattern', function(done) {
+            var file = new gutil.File({
+                path: 'test/fixtures/inject/at-sign-underscore.xml',
+                cwd: 'test/fixtures/inject/',
+                base: 'test/fixtures/inject/',
+                contents: fs.readFileSync('test/fixtures/inject/at-sign-underscore.xml')
+            });
+
+            var stream = injectFilePlugin({
+                pattern: '<!-- inject\\:<filename> -->'
+            });
+
+            stream.on('data', function(newFile) {
+                expect(newFile).to.exist;
+                expect(newFile.contents).to.exist;
+                expect(newFile.contents.toString('utf8')).to.equal(fs.readFileSync('test/expected/inject/at-sign-underscore.xml', 'utf8'));
+                done();
+            });
+
+            stream.write(file);
+            stream.end();
+        });        
+
         describe('transformation', function() {
             var file, transformMock, pattern, options;
 


### PR DESCRIPTION
@ is common in file paths for javascript package managers e.g. npm and jspm
_ is also generally common in file paths

Included a new unit test which validates support for both.